### PR TITLE
#14 - Check for unexpected response from API when using get_category()

### DIFF
--- a/leboncoin_api_wrapper/leboncoin.py
+++ b/leboncoin_api_wrapper/leboncoin.py
@@ -126,6 +126,7 @@ class Leboncoin:
         anti_captcha = create_scraper(browser="chrome")
         res = anti_captcha.get(url).json()
         if res:
+            assert isinstance(res, List), f"Unexpected answer received from API: {res!r}"
             return str(res[0]["cat_id"])
         else:
             # No category returned


### PR DESCRIPTION
https://github.com/Shinyhero36/Leboncoin-API-Wrapper/issues/14