### PR TITLE
Use Requests raise_for_status()

### DIFF
--- a/leboncoin_api_wrapper/leboncoin.py
+++ b/leboncoin_api_wrapper/leboncoin.py
@@ -151,6 +151,5 @@ class Leboncoin:
                 'DNT': '1',
             }
         )
-        if r.status_code != 200:
-            raise Exception
+        r.raise_for_status()
         return Results(data=r.json())


### PR DESCRIPTION
For now when an error code is returned by API, the lib returns a generic exception (baadddd ;))

This PR proposes to use the built-in [raise_for_status()](https://2.python-requests.org/en/master/user/quickstart/#response-status-codes)

```
nov. 18 12:41:23 raspberrypi bash[9509]: Traceback (most recent call last):
nov. 18 12:41:23 raspberrypi bash[9509]:   File "./leboncoin_scrapper.py", line 130, in <module>
nov. 18 12:41:23 raspberrypi bash[9509]:     main()
nov. 18 12:41:23 raspberrypi bash[9509]:   File "./leboncoin_scrapper.py", line 45, in main
nov. 18 12:41:23 raspberrypi bash[9509]:     scrap()
nov. 18 12:41:23 raspberrypi bash[9509]:   File "./leboncoin_scrapper.py", line 63, in scrap
nov. 18 12:41:23 raspberrypi bash[9509]:     results = search(lbc, config['searches'], config['price']['min'], config['price']['max'])
nov. 18 12:41:23 raspberrypi bash[9509]:   File "./leboncoin_scrapper.py", line 113, in search
nov. 18 12:41:23 raspberrypi bash[9509]:     result = lbc.execute()
nov. 18 12:41:23 raspberrypi bash[9509]:   File "/usr/local/lib/python3.6/site-packages/leboncoin_api_wrapper/leboncoin.py", line 119, in execute
nov. 18 12:41:23 raspberrypi bash[9509]:     raise Exception
nov. 18 12:41:23 raspberrypi bash[9509]: Exception
```